### PR TITLE
Add missing spec tests for the 'stackstorm::_packages' recipe

### DIFF
--- a/spec/recipes/_packages_spec.rb
+++ b/spec/recipes/_packages_spec.rb
@@ -7,6 +7,7 @@ describe 'stackstorm::_packages' do
 
   context 'with default node attributes' do
     let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+    let(:execute) { chef_run.execute('Ubuntu Precise and Trusty: APT hash sum mismatch workaround') }
 
     it 'should include recipe apt' do
       allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('apt')
@@ -21,6 +22,18 @@ describe 'stackstorm::_packages' do
 
     it 'should install pacakge "st2"' do
       expect(chef_run).to install_package('st2')
+    end
+
+    it 'should not install pacakge "apt"' do
+      expect(chef_run).to_not install_package('apt').with(version: '1.2.10')
+    end
+
+    it 'runs a execute "Ubuntu Precise and Trusty: APT hash sum mismatch workaround"' do
+      expect(chef_run).to run_execute('curl -s https://packagecloud.io/install/repositories/computology/apt-backport/script.deb.sh | bash')
+    end
+
+    it 'sends the notification to the apt resource immediately' do
+      expect(execute).to notify('package[apt]').to(:install).immediately
     end
   end
 end


### PR DESCRIPTION
@shortdudey123 this PR addresses your comments https://github.com/StackStorm/chef-stackstorm/pull/22#discussion_r84601028 https://github.com/StackStorm/chef-stackstorm/pull/22#discussion_r84601029 in #22

This brings ChefSpec coverage to 100% 🎉 :

![image](https://cloud.githubusercontent.com/assets/1429460/20631910/bbf453cc-b339-11e6-87c7-d8e30981e6b2.png)

@armab related with https://github.com/StackStorm/chef-stackstorm/issues/27