### PR TITLE
Add htpasswd generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,17 @@ All-in-one solution which installs and configures `st2` system services as well 
 | Key | Type | Description | Default |
 | --- | --- | :--- | --- |
 | `['stackstorm']['config']` | Hash | Various options used to build up the `st2.conf` configuration file. | *see [config.rb](attributes/config.rb)* |
+| `['stackstorm']['username']` | String | StackStorm username for simple `htpasswd`-based [authentication](https://docs.stackstorm.com/install/deb.html?highlight=flat_file#configure-authentication). | `st2admin` |
+| `['stackstorm']['password']` | String | StackStorm password. | `Ch@ngeMe` |
 
 ### System User
 To run local and remote shell actions, StackStorm uses a special _system user_ (default `stanley`). For remote Linux actions, SSH is used. It is advised to configure SSH key-based authentication on all remote hosts.
 
 | Key | Type | Description | Default |
 | --- | --- | --- | --- |
-| `['stackstorm']['user']['user']` | String | System user used by stackstorm stack. | `'stanley'` |
-| `['stackstorm']['user']['group']` | String | System group used by stackstorm stack. | `'stanley'` |
-| `['stackstorm']['user']['home']` | String | Path to stanley's home directory. | `'/home/stanley'` |
+| `['stackstorm']['user']['user']` | String | System user used by stackstorm stack. | `stanley` |
+| `['stackstorm']['user']['group']` | String | System group used by stackstorm stack. | `stanley` |
+| `['stackstorm']['user']['home']` | String | Path to stanley's home directory. | `/home/stanley` |
 | `['stackstorm']['user']['authorized_keys']` | Array | List of ssh public keys added to stanley's `~/.ssh/authorized_keys` file. | `[]` |
 | `['stackstorm']['user']['ssh_key']` | String | Stanley's ssh private key. | `nil` |
 | `['stackstorm']['user']['ssh_pub']` | String | Stanley's ssh public key. | `nil` |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,9 +19,6 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = 'chef-stackstorm'
   config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
-  # Set the version of chef to install using the vagrant-omnibus plugin
-  config.omnibus.chef_version = 'latest'
-
   # Assign this VM to a host-only network IP, allowing you to access it
   # via the IP. Host-only networks can talk to the host machine as well as
   # any other machines on the same network, but cannot be accessed (through this
@@ -42,6 +39,18 @@ Vagrant.configure(2) do |config|
     # Required for StackStorm to run properly
     vb.memory = 2048
   end
+
+  if Vagrant.has_plugin?('vagrant-hostmanager')
+    config.hostmanager.enabled = false
+    config.hostmanager.manage_host = true
+    config.hostmanager.ignore_private_ip = false
+    config.hostmanager.include_offline = true
+    config.hostmanager.aliases = ['www.chef-stackstorm']
+    config.vm.provision :hostmanager
+  end
+
+  # Set the version of chef to install using the vagrant-omnibus plugin
+  config.omnibus.chef_version = 'latest'
 
   # An array of symbols representing groups of cookbook described in the Vagrantfile
   # to exclusively install and copy to Vagrant's shelf.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,3 @@
+default['stackstorm']['username'] = 'st2admin'
+default['stackstorm']['password'] = 'Ch@ngeMe'
 default['stackstorm']['install_repo']['packages'] = %w(st2)

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,6 +21,7 @@ depends 'apt'
 depends 'yum'
 depends 'yum-epel'
 depends 'packagecloud'
+depends 'htpasswd'
 
 source_url 'https://github.com/StackStorm/chef-stackstorm' if respond_to?(:source_url)
 issues_url 'https://github.com/StackStorm/chef-stackstorm/issues' if respond_to?(:issues_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,3 +8,11 @@ include_recipe 'stackstorm::_packages'
 include_recipe 'stackstorm::user'
 include_recipe 'stackstorm::config'
 include_recipe 'stackstorm::_services'
+
+# Generate username & password for htpasswd flat-file authentication
+htpasswd ':add credentials to htpasswd file' do
+  file node['stackstorm']['config']['auth_standalone_file']
+  user node['stackstorm']['username']
+  password node['stackstorm']['password']
+  action :add
+end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -22,5 +22,13 @@ describe 'stackstorm::default' do
       expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('stackstorm::_services')
       chef_run
     end
+
+    it 'should generate htpasswd file with auth credentials' do
+      expect(chef_run).to add_htpasswd(':add credentials to htpasswd file').with(
+        file: '/etc/st2/htpasswd',
+        user: 'st2admin',
+        password: 'Ch@ngeMe'
+      )
+    end
   end
 end


### PR DESCRIPTION
> Fixes #40 

Generates `/etc/st2/htpasswd` for default auth method, according to Installation Docs: https://docs.stackstorm.com/install/deb.html#configure-authentication

I think we'll need to configure more advanced `auth` methods in a Cookbook in future, but only if that'll be really requested. One step at a time.