### PR TITLE
Recipe retouch for st2web

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -32,9 +32,3 @@ suites:
   - name: default
     run_list:
       - "recipe[stackstorm::bundle]"
-    attributes:
-      stackstorm:
-        web:
-          ssl:
-            self_signed:
-              enabled: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,9 +19,3 @@ suites:
   - name: default
     run_list:
       - "recipe[stackstorm::bundle]"
-    attributes:
-      stackstorm:
-        web:
-          ssl:
-            self_signed:
-              enabled: true

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Mind that the valid `config` options must be provided such as `RabbitMQ` and `Mo
 ### `stackstorm::bundle`
 All-in-one solution which installs and configures `st2` system services as well as all required dependencies such as `RabbitMQ`, `MongoDB`, [`st2mistral`](https://github.com/StackStorm/chef-openstack-mistral), `Nginx` and [`st2web`](https://github.com/StackStorm/st2web).
 
+### `stackstorm::web`
+Installs StackStorm Web UI control panel ([`st2web`](https://github.com/StackStorm/st2web)) and configures `nginx` as a proxy for StackStorm services.
+It will generate self-signed certificate by default, see [Install WebUI and setup SSL termination](https://docs.stackstorm.com/install/deb.html#install-webui-and-setup-ssl-termination).
+
 ## Attributes
 ### Common attributes
 | Key | Type | Description | Default |
@@ -53,8 +57,17 @@ To run local and remote shell actions, StackStorm uses a special _system user_ (
 | `['stackstorm']['user']['ssh_pub']` | String | Stanley's ssh public key. | `nil` |
 | `['stackstorm']['user']['ssh_key_bits']` | Integer | Specifies the number of bits for ssh key creation. | `2048` |
 | `['stackstorm']['user']['enable_sudo']` | Boolean | Enables sudo privileges for stanley. | `true` |
-
 Stanley's ssh key is automatically generated if no `ssh_key` is provided. If `root` privileges for running actions are required `stanley` must be a valid sudoer. This is the default behavior.
+
+### Web UI
+Settings for StackStorm Web UI `st2web` and `nginx`.
+
+| Key | Type | Description | Default |
+| --- | --- | --- | --- |
+| `['stackstorm']['web']['ssl']['self_signed']['enabled']` | Boolean | Enable self-signed certificate generation. | `true` |
+| `['stackstorm']['web']['ssl']['self_signed']['org']` | String | Self-signed certificate `O` field. | `StackStorm` |
+| `['stackstorm']['web']['ssl']['self_signed']['org_unit']` | String | Self-signed certificate `OU` field. | `Information Technology` |
+| `['stackstorm']['web']['ssl']['self_signed']['country']` | String | Self-signed certificate `C` field. | `US` |
 
 ## Authors
 * Author:: StackStorm (st2-dev) (<info@stackstorm.com>)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,2 @@
 default['stackstorm']['username'] = 'st2admin'
 default['stackstorm']['password'] = 'Ch@ngeMe'
-default['stackstorm']['install_repo']['packages'] = %w(st2)

--- a/attributes/web.rb
+++ b/attributes/web.rb
@@ -4,7 +4,7 @@
 #
 
 # Self-signed certificate
-default['stackstorm']['web']['ssl']['self_signed']['enabled'] = false
+default['stackstorm']['web']['ssl']['self_signed']['enabled'] = true
 default['stackstorm']['web']['ssl']['self_signed']['org'] = 'StackStorm'
 default['stackstorm']['web']['ssl']['self_signed']['org_unit'] = 'Information Technology'
 default['stackstorm']['web']['ssl']['self_signed']['country'] = 'US'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ supports 'centos', '~> 7.0'
 supports 'amazon'
 
 depends 'apt'
-depends 'chef_nginx', '~> 4.0.1'
+depends 'chef_nginx', '~> 5.0.1'
 depends 'database'
 depends 'htpasswd'
 depends 'mongodb3', '~> 5.3.0'

--- a/recipes/_repository.rb
+++ b/recipes/_repository.rb
@@ -1,11 +1,9 @@
 #
 # Cookbook Name:: stackstorm
-# Recipe:: install_repo
+# Recipe:: _repository
 #
 # Copyright (C) 2015 StackStorm (info@stackstorm.com)
 #
-
-# Fetches remote packages from StackStorm repository.
 
 include_recipe 'apt'
 
@@ -35,6 +33,3 @@ end
 packagecloud_repo 'StackStorm/stable' do
   type type
 end
-
-# Install packages
-node['stackstorm']['install_repo']['packages'].each { |p| package p }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,7 +4,8 @@
 #
 # Copyright (C) 2015 StackStorm (info@stackstorm.com)
 #
-include_recipe 'stackstorm::_packages'
+include_recipe 'stackstorm::_repository'
+package 'st2'
 include_recipe 'stackstorm::user'
 include_recipe 'stackstorm::config'
 include_recipe 'stackstorm::_services'

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -1,3 +1,5 @@
+include_recipe 'stackstorm::_repository'
+
 package 'st2web'
 
 node.default['nginx']['default_site_enabled'] = false

--- a/spec/recipes/_repository_spec.rb
+++ b/spec/recipes/_repository_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'stackstorm::_packages' do
+describe 'stackstorm::_repository' do
   before do
     global_stubs_include_recipe
   end
@@ -18,10 +18,6 @@ describe 'stackstorm::_packages' do
       expect(chef_run).to create_packagecloud_repo('StackStorm/stable').with(
         type: 'deb'
       )
-    end
-
-    it 'should install pacakge "st2"' do
-      expect(chef_run).to install_package('st2')
     end
 
     it 'should not install pacakge "apt"' do

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -8,9 +8,13 @@ describe 'stackstorm::default' do
   context 'with default node attributes' do
     let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-    it 'should include recipe stackstorm::_packages' do
-      expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('stackstorm::_packages')
+    it 'should include recipe stackstorm::_repository' do
+      expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('stackstorm::_repository')
       chef_run
+    end
+
+    it 'should install pacakge "st2"' do
+      expect(chef_run).to install_package('st2')
     end
 
     it 'should include recipe stackstorm::config' do

--- a/spec/recipes/web_spec.rb
+++ b/spec/recipes/web_spec.rb
@@ -8,6 +8,11 @@ describe 'stackstorm::web' do
   context 'with default node attributes' do
     let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
+    it 'should include recipe stackstorm::_repository' do
+      expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('stackstorm::_repository')
+      chef_run
+    end
+
     it 'should install pacakge "st2web"' do
       expect(chef_run).to install_package('st2web')
     end

--- a/spec/recipes/web_spec.rb
+++ b/spec/recipes/web_spec.rb
@@ -20,8 +20,8 @@ describe 'stackstorm::web' do
       )
     end
 
-    it 'should not create a self-signed certificate "/etc/ssl/st2/st2.crt"' do
-      expect(chef_run).to_not create_x509_certificate('/etc/ssl/st2/st2.crt')
+    it 'should create a self-signed certificate "/etc/ssl/st2/st2.crt"' do
+      expect(chef_run).to create_x509_certificate('/etc/ssl/st2/st2.crt')
     end
 
     it 'should include recipe chef_nginx::repo' do
@@ -39,15 +39,15 @@ describe 'stackstorm::web' do
     end
   end
 
-  context "with node['stackstorm']['web']['ssl']['self_signed']['enabled'] = true" do
+  context "with node['stackstorm']['web']['ssl']['self_signed']['enabled'] = false" do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.normal['stackstorm']['web']['ssl']['self_signed']['enabled'] = true
+        node.normal['stackstorm']['web']['ssl']['self_signed']['enabled'] = false
       end.converge(described_recipe)
     end
 
-    it 'should create a self-signed certificate "/etc/ssl/st2/st2.crt"' do
-      expect(chef_run).to create_x509_certificate('/etc/ssl/st2/st2.crt')
+    it 'should not create a self-signed certificate "/etc/ssl/st2/st2.crt"' do
+      expect(chef_run).to_not create_x509_certificate('/etc/ssl/st2/st2.crt')
     end
   end
 end

--- a/test/recipes/default/web_test.rb
+++ b/test/recipes/default/web_test.rb
@@ -13,8 +13,6 @@ describe package('nginx') do
   it { should be_installed }
 end
 
-puts package('nginx').version
-
 describe service('nginx') do
   it { should be_installed }
   it { should be_enabled }

--- a/test/recipes/default/web_test.rb
+++ b/test/recipes/default/web_test.rb
@@ -5,13 +5,25 @@
 # The Inspec reference, with examples and extensive documentation, can be
 # found at https://docs.chef.io/inspec_reference.html
 
-describe package 'st2web' do
+describe package('st2web') do
   it { should be_installed }
 end
 
-describe package 'nginx' do
+describe package('nginx') do
   it { should be_installed }
 end
+
+puts package('nginx').version
+
+describe service('nginx') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+# nginx version should be >= '1.7.5'
+# TODO: Custom matcher/resource to identify and semver compare installed package version
+# See: https://docs.stackstorm.com/install/deb.html#install-webui-and-setup-ssl-termination
 
 describe directory('/etc/ssl/st2') do
   it { should exist }
@@ -19,17 +31,21 @@ describe directory('/etc/ssl/st2') do
   its('group') { should eq 'root' }
 end
 
-# 'nginx' listens on port 80
+describe file('/etc/ssl/st2/st2.crt') do
+  it { should exist }
+end
+
+describe file('/etc/ssl/st2/st2.key') do
+  it { should exist }
+end
+
 describe port(80) do
   it { should be_listening }
 end
 
-# 'nginx' listens on port 443
 describe port(443) do
   it { should be_listening }
 end
 
-# 'st2web' listens on port 443
-describe port(9100) do
-  it { should be_listening }
-end
+# TODO: Test REST API endpoints, defined in nginx
+# Ex: http://stackoverflow.com/a/6326763/4533625


### PR DESCRIPTION
Address notes missed in https://github.com/StackStorm/chef-stackstorm/pull/45. Finalize work on https://github.com/StackStorm/chef-stackstorm/issues/24

* [x] Generate self_signed certificate by default (conform with default installer logic)
* [x] Add missing Readme notes
* [x] `web` recipe should be self-sufficient (missing packagecloud repo)
* [x] InSpec
* [x] Fix `nginx` service on `Ubuntu Trusty` (upstream bug https://github.com/chef-cookbooks/chef_nginx/pull/55 https://github.com/chef-cookbooks/chef_nginx/issues/57)
