### PR TITLE
Added creation of the group

### DIFF
--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -11,6 +11,10 @@
 
 conf = node['stackstorm']['user']
 
+group conf['group'] do
+  action :create
+end
+
 user conf['user'] do
   home conf['home']
   group conf['group']


### PR DESCRIPTION
Group was not created on CentOS 7.3. Create group to make sure it's there if user gets created and added as member.