### PR TITLE
Add 'chef_version' in cookbook metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,6 +11,8 @@ supports 'redhat', '~> 7.0'
 supports 'centos', '~> 7.0'
 supports 'amazon'
 
+chef_version '>= 12.4'
+
 depends 'apt'
 depends 'chef_nginx', '~> 5.0.1'
 depends 'database'


### PR DESCRIPTION
> Partially adresses https://github.com/StackStorm/chef-stackstorm/issues/63

Fix failing Foodcritic error:
```rb
FC066: Ensure chef_version is set in metadata: /home/travis/build/StackStorm/chef-stackstorm/metadata.rb:1
```
https://travis-ci.org/StackStorm/chef-stackstorm/jobs/221052689

This is a new error in Travis, since CI switched Chef `12` -> `13`.
