### PR TITLE
Fix Chef 13 CI build failures

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -22,9 +22,7 @@ depends 'openssl', '~> 6.0.0'
 depends 'openstack-mistral', '>= 0.3.0'
 depends 'packagecloud'
 depends 'postgresql'
-# For newer RabbitMQ cookbook versions, service fails to start in Dockerized environment under EL7
-# See: https://github.com/StackStorm/chef-stackstorm/pull/62
-depends 'rabbitmq', '<= 4.10.0'
+depends 'rabbitmq'
 depends 'sudo'
 depends 'yum'
 depends 'yum-epel'


### PR DESCRIPTION
Closes #63.

Outdated rabbitmq cookbok produces the following error (https://travis-ci.org/StackStorm/chef-stackstorm/jobs/234373310) in Chef 13:
```
 Compiling Cookbooks...
================================================================================
       Recipe Compile Error in /tmp/kitchen/cache/cookbooks/rabbitmq/resources/parameter.rb
      ================================================================================       
       ArgumentError
       -------------
       Property `params` of resource `rabbitmq_parameter` overwrites an existing method.
       
       Cookbook Trace:
       ---------------
         /tmp/kitchen/cache/cookbooks/rabbitmq/resources/parameter.rb:27:in `class_from_file'
       
       Relevant File Content:
       ----------------------
       /tmp/kitchen/cache/cookbooks/rabbitmq/resources/parameter.rb:
       
        20:  
        21:  actions :set, :clear, :list
        22:  default_action :set
        23:  
        24:  attribute :parameter, :kind_of => String, :name_attribute => true
        25:  attribute :component, :kind_of => String
        26:  attribute :vhost, :kind_of => String
        27>> attribute :params, :kind_of => [Hash, Array], :default => {}
        28:  

       System Info:
```

Seems that https://github.com/rabbitmq/chef-cookbook build is GREEN again and we can use latest `rabbitmq`.

Checking...