### PR TITLE
Add new service 'st2scheduler' (MERGE after st2 'v2.10' release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # stackstorm cookbook CHANGELOG
 
+## In Development
+ * Add new service 'st2scheduler' introduced since st2 'v3.0'
+
 ## 0.5.0
 
  * Migrate from 'mongodb' to 'sc-mongodb' cookbook for Chef 13+ support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # stackstorm cookbook CHANGELOG
 
 ## In Development
+
+
+## 0.6.0
+
  * Add new service 'st2scheduler' introduced since st2 'v3.0'
 
 ## 0.5.0

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@stackstorm.com'
 license 'Apache-2.0'
 description 'Installs/Configures stackstorm'
 long_description 'Installs/Configures stackstorm'
-version '0.5.0'
+version '0.6.0'
 
 supports 'ubuntu', '= 14.04'
 supports 'redhat', '~> 7.5'

--- a/recipes/_services.rb
+++ b/recipes/_services.rb
@@ -11,7 +11,7 @@ ST2_SERVICES = %w(
   st2actionrunner st2api st2stream
   st2auth st2garbagecollector st2notifier
   st2resultstracker st2rulesengine st2sensorcontainer
-  st2timersengine st2workflowengine
+  st2timersengine st2workflowengine st2scheduler
 ).freeze
 
 # Enable & Start st2 services

--- a/spec/recipes/_services_spec.rb
+++ b/spec/recipes/_services_spec.rb
@@ -6,7 +6,7 @@ ST2_SERVICES = %w(
   st2actionrunner st2api st2stream
   st2auth st2garbagecollector st2notifier
   st2resultstracker st2rulesengine st2sensorcontainer
-  st2timersengine st2workflowengine
+  st2timersengine st2workflowengine st2scheduler
 ).freeze
 
 describe 'stackstorm::_services' do

--- a/test/recipes/default/_services.rb
+++ b/test/recipes/default/_services.rb
@@ -11,7 +11,7 @@ ST2_SERVICES = %w(
   st2actionrunner st2api st2stream
   st2auth st2garbagecollector st2notifier
   st2resultstracker st2rulesengine st2sensorcontainer
-  st2timersengine st2workflowengine
+  st2timersengine st2workflowengine st2scheduler
 ).freeze
 
 ST2_SERVICES.each do |service_name|


### PR DESCRIPTION
Add new service `st2scheduler` that will be introduced since st2 `v2.10`.

Need to merge it + release new cookbook version.