### PR TITLE
Fix Chef License acceptance prompt failing CI build

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -7,6 +7,11 @@ driver:
   privileged: true
   use_sudo: false
 
+provisioner:
+  name: chef_zero
+  product_name: chef
+  product_version: 14.4.56
+
 verifier:
   name: inspec
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,8 @@ driver:
 
 provisioner:
   name: chef_zero
+  product_name: chef
+  product_version: 14.4.56
 
 verifier:
   name: inspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - /opt/chefdk/bin/cookstyle --version
   - /opt/chefdk/bin/foodcritic --version
   - /opt/chefdk/bin/kitchen --version
-  - KITCHEN_LOCAL_YAML=.kitchen.docker.yml /opt/chefdk/bin/chef exec rake ${SUITE}
+  - KITCHEN_LOCAL_YAML=.kitchen.docker.yml CHEF_LICENSE=accept /opt/chefdk/bin/chef exec rake ${SUITE}
 
 notifications:
   # Post build failures to '#chef' channel in 'stackstorm-community' Slack

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - /opt/chefdk/bin/cookstyle --version
   - /opt/chefdk/bin/foodcritic --version
   - /opt/chefdk/bin/kitchen --version
-  - KITCHEN_LOCAL_YAML=.kitchen.docker.yml CHEF_LICENSE=accept /opt/chefdk/bin/chef exec rake ${SUITE}
+  - KITCHEN_LOCAL_YAML=.kitchen.docker.yml /opt/chefdk/bin/chef exec rake ${SUITE}
 
 notifications:
   # Post build failures to '#chef' channel in 'stackstorm-community' Slack


### PR DESCRIPTION
Fixes https://travis-ci.org/StackStorm/chef-stackstorm/jobs/532572362 Travis build failing to run due to Chef license prompt.

```
       +---------------------------------------------+
            Chef License Acceptance
       
       Before you can continue, 2 product licenses
       must be accepted. View the license at
       https://www.chef.io/end-user-license-agreement/
       
       Licenses that need accepting:
         * Chef Infra Client
         * Chef InSpec
       
       Do you accept the 2 product licenses (yes/no)?
       
       > Prompt timed out. Use non-interactive flags or enter an answer within 60 seconds.
       
       If you do not accept this license you will
       not be able to use Chef products.
       
       Do you accept the 2 product licenses (yes/no)?
       
       > Prompt timed out. Use non-interactive flags or enter an answer within 60 seconds.
       +---------------------------------------------+
       Chef Infra Client cannot execute without accepting the license
```

See https://docs.chef.io/chef_license_accept.html